### PR TITLE
Add salt to documents and hashes going to DLT

### DIFF
--- a/.github/workflows/file-modifier.yml
+++ b/.github/workflows/file-modifier.yml
@@ -68,7 +68,7 @@ jobs:
       run: |
         python ${GITHUB_WORKSPACE}/.github/store-hash-to-dlt.py
         git add -A
-        git commit -m "Distributed ledger transaction info" -a || echo "Warning: git commit returned error code $? (Hopefully nothing to commit)"
+        git commit -m "Autoupdate salt and hash info" -a || echo "Warning: git commit returned error code $? (Hopefully nothing to commit)"
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:

--- a/.github/workflows/hash-to-dlt.yml
+++ b/.github/workflows/hash-to-dlt.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         python ${GITHUB_WORKSPACE}/.github/store-hash-to-dlt.py
         git add -A
-        git commit -m "Distributed ledger transaction info" -a || echo "Warning: git commit returned error code $? (Hopefully nothing to commit)"
+        git commit -m "Autoupdate salt and hash info" -a || echo "Warning: git commit returned error code $? (Hopefully nothing to commit)"
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ web3
 pyyaml
 requests
 dtweb
+uuid


### PR DESCRIPTION
...to improve privacy. This way, all hashes submitted to the DLT will be different thanks to the salt, even if the other contents of the twin document stay the same.

The implementation logic can be read from the .github/store-hash-to-dlt.py file.

@Scurvide please check if this breaks anything. That can of course be done after merging.

I tested the functionality locally and it seems to work as intended, but this should be validated in a working Twinbase instance.